### PR TITLE
[Pz41] Chainsaw partial fix+ solar gen grid update on disconnect.

### DIFF
--- a/media/lua/client/Chainsaw/chainsaw.lua
+++ b/media/lua/client/Chainsaw/chainsaw.lua
@@ -3,17 +3,22 @@ local MOD_ID = "ChainSaw";
 local timeDown = 0;
 
 function chainsaw_swing(owner, weapon)
-	
-	if owner:getPrimaryHandItem() and owner:getPrimaryHandItem():getType() == "ChainSaw" then	
-		
+	local gasconsume = 3
+	if owner:getPrimaryHandItem() and owner:getPrimaryHandItem():getType() == "ChainSaw" then
 		getSoundManager():PlayWorldSound('cs_hit', true, owner:getCurrentSquare(), 0, 4, 1, false);
+		addSound(player, player:getX(), player:getY(), player:getZ(), 55, 55);
+		weapon:getModData().gasUse = weapon:getModData().gasUse - gasconsume;
+	elseif owner:getPrimaryHandItem() and owner:getPrimaryHandItem():getType() == "ChainSawNoGas" then
+		player:Say("ChainSaw, no gas");
 	
 	end
 end
 
-function chainsaw_hit(wielder, weapon, damage)
-	local player = wielder;
-	
+function chainsaw_gas_idle()
+	local weapon = getPlayer():getPrimaryHandItem();
+	if weapon and weapon:getType() == "ChainSaw" then	
+		weapon:getModData().gasUse = weapon:getModData().gasUse - 1;
+	end
 end
 
 function chainsaw_equip(leftHandItem)
@@ -48,33 +53,20 @@ function chainsaw_func(player)
 				
 			if timeDown % 25 == 0 then
 				getSoundManager():PlayWorldSoundWav('cs_idle', false, player:getSquare(), 0, 0, 0, false);
-				addSound(player, player:getX(), player:getY(), player:getZ(), 35, 35);
+				addSound(player, player:getX(), player:getY(), player:getZ(), 25, 25);
 			end
 			
 			if(weapon:getModData().gasUse <= 0) then
-				
 				player:getInventory():Remove(weapon);
 				weapon = player:getInventory():AddItem("Hydrocraft.ChainSawNoGas");
 				weapon:getModData().gasUse = 0;
 				player:setPrimaryHandItem(weapon);
 				player:setSecondaryHandItem(weapon); 
-				
-			elseif timeDown % 200 == 0 then
-				weapon:getModData().gasUse = weapon:getModData().gasUse - 1;
-				player:Say("ChainSaw Gas:" .. tostring(weapon:getModData().gasUse) .. "%");
 			end
 			-- print(timeDown);
 		
 		end
 	end
-end
-
-function chainsaw_add(player, square)
-	player:getInventory():AddItem("Hydrocraft.ChainSawNoGas");
-	player:getInventory():AddItem("Base.PetrolCan");
-	--player:getInventory():AddItem("Hydrocraft.HCBattleaxebronze");
-	--player:getInventory():AddItem("ORGM.BenelliM3PASO");
-
 end
 
 function chainsaw_init() -- probably not needed anymore
@@ -109,9 +101,7 @@ end
 Events.OnGameBoot.Add(chainsaw_loadModel);
 Events.OnEquipPrimary.Add(chainsaw_equip);
 Events.OnWeaponSwing.Add(chainsaw_swing);
---Events.OnWeaponHitCharacter.Add(chainsaw_hit);
---Events.OnWeaponHitTree.Add(chainsaw_hit);
+Events.EveryTenMinutes.Add(chainsaw_gas_idle);
 Events.OnPlayerUpdate.Add(chainsaw_func);
---Events.OnNewGame.Add(chainsaw_add);
 Events.OnGameStart.Add(chainsaw_init);
 

--- a/media/lua/client/Chainsaw/cs_contextmenu.lua
+++ b/media/lua/client/Chainsaw/cs_contextmenu.lua
@@ -62,11 +62,4 @@ ChainSawMenu.onFill = function(item, player)
 	
 end
 
-
-
-
-
-
-
-
 Events.OnFillInventoryObjectContextMenu.Add(ChainSawMenu.doMenu);

--- a/media/lua/client/Solar/solar.lua
+++ b/media/lua/client/Solar/solar.lua
@@ -11,6 +11,7 @@ function HCRemoveSolarGen(items, result, player)
             NewGenerator:setFuel(0);
             NewGenerator:setCondition(0);
             NewGenerator:setActivated(false);
+			NewGenerator:setSurroundingElectricity();
             NewGenerator:remove();
                        
         
@@ -31,7 +32,7 @@ function HCSetSolarGen(items, result, player)
                 NewGenerator:setFuel(100);
                 NewGenerator:setCondition(100);
                 NewGenerator:setActivated(true);
-				NewGenerator:setSurroundingElectricity() ;
+				NewGenerator:setSurroundingElectricity();
                 NewGenerator:remove();
                 player:getCurrentSquare():AddWorldInventoryItem( "Hydrocraft.HCSolargen2" ,0.5,0.5,0);
                               

--- a/media/scripts/Drugs Tobacco.txt
+++ b/media/scripts/Drugs Tobacco.txt
@@ -136,6 +136,7 @@ item HCCigar
 	HungerChange			=	0,
 	Weight				=	0.1,
 	RequireInHandOrInventory	=	Lighter/Matches,
+	Icon				=	HCCigar,
 	Type				=	Food,
 	UnhappyChange			=	10,
 	DisplayName			=	Cigar,

--- a/media/scripts/Tools.txt
+++ b/media/scripts/Tools.txt
@@ -853,7 +853,7 @@ item HCScissorlift
         	MinimumSwingTime    				=    	6.00,
         	KnockBackOnNoDeath    				=    	True,
         	SwingAmountBeforeImpact    			=    	0.12,
-        	Categories    					=    	Blade,
+        	Categories    					=    	Axe,
         	ConditionLowerChanceOneIn    			=    	600,
         	Weight    					=    	7,
         	RequiresEquippedBothHands 			= 	true,
@@ -879,7 +879,7 @@ item HCScissorlift
         	RunAnim    					=    	Run_Weapon2,
         	TwoHandWeapon 					= 	TRUE,
         	BreakSound  					=   	BreakMetalItem,
-        	TreeDamage  					=   	125,
+        	TreeDamage  					=   	500,
         
     }
     


### PR DESCRIPTION
    Chainsaw rewrite:
    - higher tree damage when with gas (so will take tree down with one swwing
    - fuel consumption based on time and not ticks (or whatever it was, drianed whole gas in 10 in game minutes while idle)
    - changed sound volume on idle and while 'runnig'
    - gas one will be able to used with pz41 "cut tree" menu
    Notes/Todo:
    - condition will never go down as code now replace chinsaw (gas/noGas) with brand new object
    - cutting tree with "cut tree" is silent (no chainsaw sound) and will not use fuel -> could not find valid event to subscriibe and rather 'd like not to fork off ChopTree class from PZ for this.


 Add Icon definiton to Cigar (caused exceptions with advanced trading post), six power grid when disconnecting solar gen.