### PR TITLE
Update Electronics.txt - Textual fix

### DIFF
--- a/media/scripts/Electronics.txt
+++ b/media/scripts/Electronics.txt
@@ -919,7 +919,7 @@ recipe Loot Electronic Parts
        	OnGiveXP:HCElectricity_OnGiveXP,
     }
 
-recipe Loot Electronics Parts
+recipe Loot Electronic Parts
     {
        	SkillRequired:Electricity=1,
        	ElectronicsScrap=2,


### PR DESCRIPTION
Fixed 'Loot Electronics Parts' for ElectronicsScrap to recipe learned from Books.txt -> HCBookelectrical -> 'Loot Electronic Parts' to match and to allow HCCabletangle to be obtained. Tested in 40.43 MP.